### PR TITLE
build: Add required permissions for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     environment: CIRelease
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Set up JDK 17


### PR DESCRIPTION
Closes #8 

Reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs